### PR TITLE
Parse higher-order specifications

### DIFF
--- a/prusti-interface/src/specs/typed.rs
+++ b/prusti-interface/src/specs/typed.rs
@@ -81,11 +81,9 @@ impl<'tcx> Spanned<'tcx> for Assertion<'tcx> {
                 // FIXME: include the conditions
                 body.get_spans(tcx)
             }
-            AssertionKind::SpecEnt(ref cl_name, ref _binders, ref pre, ref post) => {
-                pre.get_spans(tcx)
-                   .into_iter()
-                   .chain(post.get_spans(tcx))
-                   .collect()
+            AssertionKind::SpecEnt(ref cl, ref _binders, ref _pres, ref _posts) => {
+                // FIXME: include the specification
+                cl.get_spans(tcx)
             }
         }
     }

--- a/prusti-interface/src/specs/typed.rs
+++ b/prusti-interface/src/specs/typed.rs
@@ -81,9 +81,18 @@ impl<'tcx> Spanned<'tcx> for Assertion<'tcx> {
                 // FIXME: include the conditions
                 body.get_spans(tcx)
             }
-            AssertionKind::SpecEnt(ref cl, ref _binders, ref _pres, ref _posts) => {
-                // FIXME: include the specification
-                cl.get_spans(tcx)
+            AssertionKind::SpecEnt(ref cl, ref _args, ref pres, ref posts) => {
+                let mut spans = cl.get_spans(tcx);
+                // FIXME: include the arguments
+                spans.extend(pres
+                    .iter()
+                    .flat_map(|a| a.get_spans(tcx))
+                    .collect::<Vec<Span>>());
+                spans.extend(posts
+                    .iter()
+                    .flat_map(|a| a.get_spans(tcx))
+                    .collect::<Vec<Span>>());
+                spans
             }
         }
     }

--- a/prusti-specs/src/specifications/common.rs
+++ b/prusti-specs/src/specifications/common.rs
@@ -211,12 +211,12 @@ pub enum AssertionKind<EID, ET, AT> {
         TriggerSet<EID, ET>,
         Assertion<EID, ET, AT>,
     ),
-    /// Specification entailment: spec_ent(closure, argument binders, precond, postcond)
+    /// Specification entailment: spec_ent(closure, argument binders, pres, posts)
     SpecEnt(
-        String, // closure name
+        Expression<EID, ET>, // closure
         SpecEntVars<EID, AT>, // argument binders
-        Assertion<EID, ET, AT>, // precondition
-        Assertion<EID, ET, AT>, // postcondition
+        Vec<Assertion<EID, ET, AT>>, // preconditions
+        Vec<Assertion<EID, ET, AT>>, // postconditions
     )
 }
 

--- a/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-specs/src/specifications/preparser.rs
@@ -529,8 +529,9 @@ impl Parser {
 
         // specification entailments are in one of the following forms:
         //   expr |= |arg, arg, ...| [ requires(...), ensures(...), ... ]
-        //   expr |= |arg, arg, ...| requires(...)
         //   expr |= [ requires(...), ensures(...), ... ]
+        // TODO: (after discussion on syntax)
+        //   expr |= |arg, arg, ...| requires(...)
         //   expr |= requires(...)
         // by this point we have already consumed expr and |=
 

--- a/prusti-specs/src/specifications/preparser.rs
+++ b/prusti-specs/src/specifications/preparser.rs
@@ -2,7 +2,7 @@
 /// parses the resulting Rust expressions, and then assembles the composite
 /// Prusti assertion.
 
-use proc_macro2::{Delimiter, Group, Span, TokenStream, TokenTree, Ident};
+use proc_macro2::{Delimiter, Group, Span, TokenStream, TokenTree};
 use std::collections::VecDeque;
 use std::mem;
 use syn::parse::{ParseStream, Parse};
@@ -137,6 +137,7 @@ impl ParserStream {
     /// Check whether the input starts with an operator. Does not set the span.
     fn peek_any_operator(&self) -> bool {
         self.peek_operator("==>") || self.peek_operator("&&")
+            || self.peek_operator("||") || self.peek_operator("|=")
     }
     /// Check if the input starts with the operator and if yes, consume it
     /// and set the span to it.
@@ -157,11 +158,11 @@ impl ParserStream {
         self.span = span.unwrap();
         true
     }
-    /// Check if the input starts with a parenthesized block and if yes,
-    /// consume it and set the span to it.
-    fn check_and_consume_parenthesized_block(&mut self) -> Option<Group> {
+    /// Check if the input starts with a block delimited with the given
+    /// delimiter and if yes, consume it and set the span to it.
+    fn check_and_consume_block(&mut self, delimiter: Delimiter) -> Option<Group> {
         if let Some(TokenTree::Group(group)) = self.tokens.front() {
-            if group.delimiter() == Delimiter::Parenthesis {
+            if group.delimiter() == delimiter {
                 if let Some(TokenTree::Group(group)) = self.pop() {
                     self.span = group.span();
                     return Some(group);
@@ -171,6 +172,11 @@ impl ParserStream {
             }
         }
         None
+    }
+    /// Check if the input starts with a parenthesized block and if yes,
+    /// consume it and set the span to it.
+    fn check_and_consume_parenthesized_block(&mut self) -> Option<Group> {
+        self.check_and_consume_block(Delimiter::Parenthesis)
     }
     /// Check if the input starts with a parenthesized block and if yes,
     /// set the span to it.
@@ -508,75 +514,92 @@ impl Parser {
             return Err(self.error_expected_parenthesis());
         }
     }
-
     fn resolve_spec_ent(&mut self) -> syn::Result<()> {
-        if self.expected_operator {
-            return Err(self.error_expected_operator());
+        // handles the case when there is no lhs of the |= operator
+        if !self.expected_operator {
+            return Err(self.error_expected_assertion());
         }
 
-        // check whether there is a parenthesized block after spec_ent
-        if let Some(group) = self.input.check_and_consume_parenthesized_block() {
-            // construct a ParserStream off of the parenthesized block for further parsing
-            let mut stream = ParserStream::from_token_stream(group.stream());
+        // handles the case when there is no rhs of the |= operator
+        if self.input.is_empty() {
+            return Err(self.error_expected_assertion());
+        }
 
-            // parse closure name (should be an expression at some point)
-            let token_stream = stream.create_stream_until(",");
-            if token_stream.is_empty() {
-                return Err(self.error_no_closure_ident());
-            }
-            let cl_name: Ident = syn::parse2(token_stream)?;
-            if !stream.check_and_consume_operator(",") {
-                return Err(self.error_expected_comma());
-            }
+        let lhs = self.extract_rust_expression()?;
 
-            // parse vars
-            if !stream.check_and_consume_operator("|") {
-                return Err(self.error_expected_or());
-            }
-            let token_stream = stream.create_stream_until("|");
+        // specification entailments are in one of the following forms:
+        //   expr |= |arg, arg, ...| [ requires(...), ensures(...), ... ]
+        //   expr |= |arg, arg, ...| requires(...)
+        //   expr |= [ requires(...), ensures(...), ... ]
+        //   expr |= requires(...)
+        // by this point we have already consumed expr and |=
+
+        // parse args
+        let vars = if !self.input.check_and_consume_operator("|") {
+            vec![]
+        } else {
+            let token_stream = self.input.create_stream_until("|");
             if token_stream.is_empty() {
+                // FIXME: is this really an error?
                 return Err(self.error_no_quantifier_arguments());
             }
             let all_args: SpecEntArgs = syn::parse2(token_stream)?;
-            if !stream.check_and_consume_operator("|") {
+            if !self.input.check_and_consume_operator("|") {
                 return Err(self.error_expected_or());
             }
-            let mut vars = vec![];
-            for var in all_args.args {
-                vars.push(Arg {
-                    typ: var.typ,
-                    name: var.name
-                })
+            all_args.args.into_iter()
+                         .map(|var| Arg { typ: var.typ, name: var.name })
+                         .collect()
+        };
+
+        if let Some(group) = self.input.check_and_consume_block(Delimiter::Bracket) {
+            // parse specification
+            let mut parser = Parser::from_token_stream(group.stream());
+            let mut pres = vec![];
+            let mut posts = vec![];
+            // TODO: pledges
+            //let mut pledges = vec![];
+            loop {
+                use common::SpecType::*;
+                if parser.input.is_empty() {
+                    break
+                }
+                let kind = if parser.input.check_and_consume_keyword("requires") {
+                    Precondition
+                } else if parser.input.check_and_consume_keyword("ensures") {
+                    Postcondition
+                } else {
+                    // TODO: invariant, pledge ...
+                    return Err(self.error_expected_specification());
+                };
+                let conjunct = if let Some(group) = parser.input.check_and_consume_parenthesized_block() {
+                    let mut parser = Parser::from_token_stream(group.stream());
+                    parser.extract_assertion()?
+                } else {
+                    return Err(self.error_expected_parenthesis());
+                };
+                if !parser.input.check_and_consume_operator(",") {
+                    if !parser.input.is_empty() {
+                        return Err(self.error_expected_comma());
+                    }
+                }
+                (match kind {
+                    Precondition => &mut pres,
+                    Postcondition => &mut posts,
+                    _ => unreachable!()
+                }).push(conjunct);
             }
-
-            if !stream.check_and_consume_operator(",") {
-                return Err(self.error_expected_comma());
-            }
-
-            // parse precondition
-            let token_stream = stream.create_stream_until(",");
-            let mut parser = Parser::from_token_stream(token_stream);
-            let precond = parser.extract_assertion()?;
-
-            if !stream.check_and_consume_operator(",") {
-                return Err(self.error_expected_comma());
-            }
-
-            // parse postcondition
-            let token_stream = stream.create_stream();
-            let mut parser = Parser::from_token_stream(token_stream);
-            let postcond = parser.extract_assertion()?;
 
             let conjunct = AssertionWithoutId {
                 kind: Box::new(common::AssertionKind::SpecEnt(
-                    cl_name.to_string(),
+                    lhs,
                     SpecEntVars {
                         spec_id: common::SpecificationId::dummy(),
                         id: (),
                         vars
                     },
-                    precond,
-                    postcond
+                    pres,
+                    posts,
                 ))
             };
 
@@ -585,12 +608,10 @@ impl Parser {
             self.expected_only_operator = true;
             self.expected_operator = true;
             return Ok(());
-        }
-        else {
-            return Err(self.error_expected_parenthesis());
+        } else {
+            return Err(self.error_expected_bracket());
         }
     }
-
     fn resolve_parenthesized_block(&mut self, group: Group) -> syn::Result<()>{
         // handling a parenthesized block
         if self.expected_only_operator {
@@ -660,7 +681,7 @@ impl Parser {
                     return Err(err);
                 }
             }
-            else if self.input.check_and_consume_keyword("spec_ent") {
+            else if self.input.check_and_consume_operator("|=") {
                 if let Err(err) = self.resolve_spec_ent() {
                     return Err(err);
                 }
@@ -702,6 +723,19 @@ impl Parser {
             return Err(err);
         }
         maybe_expr
+    }
+    fn extract_rust_expression(&mut self) -> syn::Result<ExpressionWithoutId> {
+        let expr = self.expr.clone();
+        let mut token_stream = TokenStream::new();
+        token_stream.extend(expr.into_iter());
+        self.expr.clear();
+        let parsed_expr = self.parse_rust_expression(token_stream.clone())?;
+
+        Ok(ExpressionWithoutId {
+            spec_id: common::SpecificationId::dummy(),
+            id: (),
+            expr: parsed_expr,
+        })
     }
     pub fn extract_pledge(&mut self) -> syn::Result<PledgeWithoutId> {
         self.parsing_pledge_with_lhs = true;
@@ -756,18 +790,7 @@ impl Parser {
     }
     /// Convert parsed Rust expression into a Prusti conjunct.
     fn convert_expr_into_conjunct(&mut self) -> syn::Result<()> {
-        let expr = self.expr.clone();
-        let mut token_stream = TokenStream::new();
-        token_stream.extend(expr.into_iter());
-        self.expr.clear();
-
-        let parsed_expr = self.parse_rust_expression(token_stream.clone())?;
-
-        let expr = ExpressionWithoutId {
-            spec_id: common::SpecificationId::dummy(),
-            id: (),
-            expr: parsed_expr,
-        };
+        let expr = self.extract_rust_expression()?;
         self.conjuncts.push(AssertionWithoutId{
             kind: Box::new(common::AssertionKind::Expr(expr))
         });
@@ -781,10 +804,13 @@ impl Parser {
         syn::Error::new(self.input.span, "expected Prusti assertion")
     }
     fn error_expected_operator(&self) -> syn::Error {
-        syn::Error::new(self.input.span, "expected `&&` or `==>`")
+        syn::Error::new(self.input.span, "expected `&&`, `==>`, or `|=`")
     }
     fn error_expected_parenthesis(&self) -> syn::Error {
         syn::Error::new(self.input.span, "expected `(`")
+    }
+    fn error_expected_bracket(&self) -> syn::Error {
+        syn::Error::new(self.input.span, "expected `[`")
     }
     fn error_expected_comma(&self) -> syn::Error {
         syn::Error::new(self.input.span, "expected `,`")
@@ -794,6 +820,9 @@ impl Parser {
     }
     fn error_expected_triggers(&self) -> syn::Error {
         syn::Error::new(self.input.span, "expected `triggers`")
+    }
+    fn error_expected_specification(&self) -> syn::Error {
+        syn::Error::new(self.input.span, "expected `requires` or `ensures`")
     }
     fn error_expected_equals(&self) -> syn::Error {
         syn::Error::new(self.input.span, "expected `=`")
@@ -807,7 +836,4 @@ impl Parser {
     fn error_no_quantifier_arguments(&self) -> syn::Error {
         syn::Error::new(self.input.span, "a quantifier must have at least one argument")
     }
-    fn error_no_closure_ident(&self) -> syn::Error {
-        syn::Error::new(self.input.span, "missing closure identifier")
-    }
-}
+ }

--- a/prusti-specs/src/specifications/untyped.rs
+++ b/prusti-specs/src/specifications/untyped.rs
@@ -7,7 +7,7 @@ use syn::spanned::Spanned;
 
 pub use common::{ExpressionId, SpecType, SpecificationId};
 pub use super::preparser::{Parser, Arg};
-use crate::specifications::common::ForAllVars;
+use crate::specifications::common::{ForAllVars, SpecEntVars};
 
 /// A specification that has no types associated with it.
 pub type Specification = common::Specification<ExpressionId, syn::Expr, Arg>;
@@ -154,6 +154,20 @@ impl AssignExpressionId<ForAllVars<ExpressionId, Arg>> for common::ForAllVars<()
     }
 }
 
+impl AssignExpressionId<SpecEntVars<ExpressionId, Arg>> for common::SpecEntVars<(), Arg> {
+    fn assign_id(
+        self,
+        spec_id: SpecificationId,
+        id_generator: &mut ExpressionIdGenerator,
+    ) -> SpecEntVars<ExpressionId, Arg> {
+        SpecEntVars {
+            spec_id,
+            id: id_generator.generate(),
+            vars: self.vars
+        }
+    }
+}
+
 impl AssignExpressionId<TriggerSet> for common::TriggerSet<(), syn::Expr> {
     fn assign_id(
         self,
@@ -198,11 +212,17 @@ impl AssignExpressionId<AssertionKind> for common::AssertionKind<(), syn::Expr, 
                 triggers.assign_id(spec_id, id_generator),
                 body.assign_id(spec_id, id_generator)
             ),
-            SpecEnt(clname, args, pre, post) => SpecEnt(
-                clname,
+            SpecEnt(cl, args, pres, posts) => SpecEnt(
+                cl.assign_id(spec_id, id_generator),
                 args.assign_id(spec_id, id_generator),
-                pre.assign_id(spec_id, id_generator),
-                post.assign_id(spec_id, id_generator)
+                pres.into_iter()
+                    .map(|assertion|
+                        Assertion { kind: assertion.kind.assign_id(spec_id, id_generator) })
+                    .collect(),
+                posts.into_iter()
+                     .map(|assertion|
+                         Assertion { kind: assertion.kind.assign_id(spec_id, id_generator) })
+                     .collect(),
             ),
             x => unimplemented!("{:?}", x),
         }
@@ -311,23 +331,9 @@ impl EncodeTypeCheck for Assertion {
                 };
                 tokens.extend(typeck_call);
             }
-            AssertionKind::SpecEnt(clname, args, pre, post) => {
-                let vec_of_vars = &args.vars;
-                let span = Span::call_site();
-                let identifier = format!("{}_{}", args.spec_id, args.id);
-
-                let mut nested_assertion = TokenStream::new();
-                body.encode_type_check(&mut nested_assertion);
-                triggers.encode_type_check(&mut nested_assertion);
-
-                let typeck_call = quote_spanned! { span =>
-                    #[prusti::spec_only]
-                    #[prusti::expr_id = #identifier]
-                    |#(#vec_of_vars),*| {
-                        #nested_assertion
-                    };
-                };
-                tokens.extend(typeck_call);
+            AssertionKind::SpecEnt(_cl, _args, _pres, _posts) => {
+                // TODO!
+                unimplemented!("spec_ent");
             }
             x => {
                 unimplemented!("{:?}", x);


### PR DESCRIPTION
PR parent: https://github.com/viperproject/prusti-dev/pull/138
cc @vakaras @fpoli

This adds parsing of specification entailments (aka higher-order specifications) using the `|=` operator:

```rust
#[requires(a |= [
  requires(a > 0),
  ensures(result > 0)
])]
```

Exact syntax should be decided in a Prusti team discussion.